### PR TITLE
feat: add grammar coverage testing infrastructure

### DIFF
--- a/.github/workflows/test-on-repo.yaml
+++ b/.github/workflows/test-on-repo.yaml
@@ -54,6 +54,11 @@ jobs:
       - name: Check formats
         run: npm run format:check
 
+      # Grammar coverage: every named node type and field must appear in at
+      # least one corpus test (100% threshold enforced).
+      - name: Check corpus coverage
+        run: python coverage.py --min-node-pct 100 --min-field-pct 100
+
       # Run tests
       - name: Test the parser on repositories
         run: |

--- a/coverage.py
+++ b/coverage.py
@@ -1,0 +1,147 @@
+"""Grammar coverage report for tree-sitter-move-on-aptos.
+
+Measures how many named node types and named fields defined in
+src/node-types.json are exercised by at least one corpus test in
+test/corpus/*.txt.
+
+Usage:
+    python coverage.py [--min-node-pct N] [--min-field-pct N] [--verbose]
+
+Exit code is non-zero if coverage is below the minimum thresholds.
+"""
+import argparse
+import glob
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent
+NODE_TYPES_PATH = REPO_ROOT / "src" / "node-types.json"
+CORPUS_GLOB = str(REPO_ROOT / "test" / "corpus" / "*.txt")
+
+# Node types that are grammar limitations or not yet implemented —
+# excluded from the "uncovered" report so the gap list stays actionable.
+KNOWN_GAPS = {
+    "proof_body",        # proof { } blocks: V2.5 spec feature, not yet supported
+    "proof_statement",   # same
+}
+
+
+def load_node_types():
+    with open(NODE_TYPES_PATH) as f:
+        return json.load(f)
+
+
+def corpus_text():
+    parts = []
+    for path in sorted(glob.glob(CORPUS_GLOB)):
+        with open(path) as f:
+            parts.append(f.read())
+    return "\n".join(parts)
+
+
+def covered_nodes_and_fields(text):
+    node_re = re.compile(r'\((\w+)')
+    field_re = re.compile(r'  (\w+): \(')
+    nodes = set(m.group(1) for m in node_re.finditer(text))
+    fields = set(m.group(1) for m in field_re.finditer(text))
+    return nodes, fields
+
+
+def analyze(node_types, corpus):
+    covered_nodes, covered_fields = covered_nodes_and_fields(corpus)
+
+    named_nodes = [n for n in node_types if n.get("named") and not n["type"].startswith("_")]
+
+    node_results = []
+    for n in named_nodes:
+        ntype = n["type"]
+        node_results.append({
+            "type": ntype,
+            "covered": ntype in covered_nodes,
+            "known_gap": ntype in KNOWN_GAPS,
+        })
+
+    field_results = []
+    for n in named_nodes:
+        for fname, fdef in n.get("fields", {}).items():
+            # Skip fields whose values are exclusively anonymous tokens — those
+            # cannot appear as named nodes in S-expression output.
+            types = fdef.get("types", [])
+            if not any(t.get("named") for t in types):
+                continue
+            field_results.append({
+                "node": n["type"],
+                "field": fname,
+                "covered": fname in covered_fields,
+            })
+
+    return node_results, field_results
+
+
+def print_report(node_results, field_results, verbose):
+    total_nodes = len(node_results)
+    covered_nodes = sum(1 for n in node_results if n["covered"])
+    actionable_uncovered = [n for n in node_results if not n["covered"] and not n["known_gap"]]
+
+    total_fields = len(field_results)
+    covered_fields = sum(1 for f in field_results if f["covered"])
+    uncovered_fields = [f for f in field_results if not f["covered"]]
+
+    node_pct = 100.0 * covered_nodes / total_nodes if total_nodes else 0
+    field_pct = 100.0 * covered_fields / total_fields if total_fields else 0
+
+    print(f"Node type coverage:  {covered_nodes}/{total_nodes} ({node_pct:.1f}%)")
+    print(f"Named field coverage: {covered_fields}/{total_fields} ({field_pct:.1f}%)")
+
+    if actionable_uncovered:
+        print(f"\nUncovered node types ({len(actionable_uncovered)}):")
+        for n in sorted(actionable_uncovered, key=lambda x: x["type"]):
+            print(f"  {n['type']}")
+
+    known_gap_nodes = [n for n in node_results if not n["covered"] and n["known_gap"]]
+    if known_gap_nodes and verbose:
+        print(f"\nKnown grammar-limitation gaps ({len(known_gap_nodes)}) [excluded from threshold]:")
+        for n in sorted(known_gap_nodes, key=lambda x: x["type"]):
+            print(f"  {n['type']}")
+
+    if uncovered_fields:
+        print(f"\nUncovered named fields ({len(uncovered_fields)}):")
+        for f in sorted(uncovered_fields, key=lambda x: (x["node"], x["field"])):
+            print(f"  {f['node']}.{f['field']}")
+
+    if verbose and covered_nodes == total_nodes and not uncovered_fields:
+        print("\nFull coverage achieved.")
+
+    return node_pct, field_pct
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Grammar corpus coverage report")
+    parser.add_argument("--min-node-pct", type=float, default=0.0,
+                        help="Fail if node coverage is below this percentage (default: 0)")
+    parser.add_argument("--min-field-pct", type=float, default=0.0,
+                        help="Fail if field coverage is below this percentage (default: 0)")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Show known-gap list and full-coverage confirmation")
+    args = parser.parse_args()
+
+    node_types = load_node_types()
+    corpus = corpus_text()
+    node_results, field_results = analyze(node_types, corpus)
+    node_pct, field_pct = print_report(node_results, field_results, args.verbose)
+
+    failed = False
+    if node_pct < args.min_node_pct:
+        print(f"\nFAIL: node coverage {node_pct:.1f}% < required {args.min_node_pct}%")
+        failed = True
+    if field_pct < args.min_field_pct:
+        print(f"\nFAIL: field coverage {field_pct:.1f}% < required {args.min_field_pct}%")
+        failed = True
+
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/diff-test.py
+++ b/diff-test.py
@@ -1,0 +1,120 @@
+"""Differential grammar test for tree-sitter-move-on-aptos.
+
+Parses every .move file reachable from the given paths and checks for two
+classes of problems that batch-test.py does not catch:
+
+1. Hidden ERROR / MISSING nodes — tree-sitter accepted the file (exit 0) but
+   inserted error-recovery nodes internally.  These indicate the grammar is
+   over-accepting and silently mis-parsing real code.
+
+2. Unknown node types — node types that appear in parse output but are not
+   listed in src/node-types.json.  This should never happen; it would signal a
+   bug in the grammar or node-types.json generation.
+
+Usage:
+    python diff-test.py PATH [PATH ...] [--only-stats]
+
+Exit code is non-zero if any file has hidden errors (unless --only-stats).
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+from config import exclude
+
+REPO_ROOT = Path(__file__).parent
+NODE_TYPES_PATH = REPO_ROOT / "src" / "node-types.json"
+
+# Tree-sitter S-expression patterns
+ERROR_RE = re.compile(r'\(ERROR ')
+MISSING_RE = re.compile(r'\(MISSING ')
+NODE_NAME_RE = re.compile(r'\(([a-z_][a-z0-9_]*)(?: |\n)')
+
+
+def load_known_types() -> set:
+    with open(NODE_TYPES_PATH) as f:
+        return {n["type"] for n in json.load(f) if n.get("named")}
+
+
+def retain_file(path: str) -> bool:
+    return all(excl not in path for excl in exclude)
+
+
+def walk_move_files(root: str) -> List[str]:
+    result = []
+    for dirpath, _, files in os.walk(root):
+        for fname in files:
+            if fname.endswith(".move"):
+                full = os.path.join(dirpath, fname)
+                if retain_file(full):
+                    result.append(full)
+    return result
+
+
+def parse_file(path: str) -> Tuple[bool, str]:
+    proc = subprocess.run(["tree-sitter", "parse", path], capture_output=True)
+    output = proc.stdout.decode("utf-8", errors="replace")
+    return proc.returncode == 0, output
+
+
+def check_file(path: str, known_types: set) -> List[str]:
+    ok, output = parse_file(path)
+    if not ok:
+        return []  # batch-test.py already catches parse failures
+
+    problems = []
+    if ERROR_RE.search(output):
+        # Find the first ERROR location
+        m = re.search(r'\(ERROR \[(\d+), \d+\]', output)
+        loc = f"[{m.group(1)},…]" if m else ""
+        problems.append(f"  hidden ERROR node {loc}")
+    if MISSING_RE.search(output):
+        m = re.search(r'\(MISSING [^\]]+\[(\d+), \d+\]', output)
+        loc = f"[{m.group(1)},…]" if m else ""
+        problems.append(f"  hidden MISSING node {loc}")
+
+    unknown = {n for n in NODE_NAME_RE.findall(output) if n not in known_types}
+    for u in sorted(unknown):
+        problems.append(f"  unknown node type: {u}")
+
+    return problems
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Differential grammar test")
+    parser.add_argument("PATH", nargs="+", help="Directories to search")
+    parser.add_argument("--only-stats", action="store_true",
+                        help="Print statistics only; do not fail on errors")
+    args = parser.parse_args()
+
+    known_types = load_known_types()
+    files: List[str] = []
+    for p in args.PATH:
+        if not os.path.isdir(p):
+            print(f"Not a directory: {p}", file=sys.stderr)
+            sys.exit(1)
+        files.extend(walk_move_files(p))
+
+    hidden_errors = 0
+    checked = 0
+    for path in sorted(files):
+        problems = check_file(path, known_types)
+        if problems:
+            print(f"[DIFF] {path}")
+            for prob in problems:
+                print(prob)
+            hidden_errors += 1
+        checked += 1
+
+    print(f"\nChecked {checked} files; {hidden_errors} with hidden parse errors.")
+    if hidden_errors and not args.only_stats:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -754,3 +754,277 @@ module 0x1::test {
         name: (identifier)
         parameters: (function_parameters)
         body: (block)))))
+
+================================================================================
+Inline function modifier
+================================================================================
+
+module 0x1::test {
+    inline fun double(x: u64): u64 {
+        x * 2
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (function_declaration
+        (inline_modifier)
+        name: (identifier)
+        parameters: (function_parameters
+          (function_parameter
+            name: (identifier)
+            type: (primitive_type)))
+        return_type: (primitive_type)
+        body: (block
+          (binary_expression
+            lhs: (name_expression
+              (name_access_chain
+                (identifier)))
+            rhs: (num_literal)))))))
+
+================================================================================
+Access specifiers: reads, writes, pure
+================================================================================
+
+module 0x1::test {
+    struct R has key { v: u64 }
+    fun reader(addr: address): u64 reads R {
+        0
+    }
+    fun writer(addr: address) writes R {
+    }
+    fun pure_fn(x: u64): u64 pure {
+        x
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (struct_declaration
+        name: (identifier)
+        abilities: (ability_declarations
+          (ability))
+        fields: (struct_fields
+          (field_declaration
+            name: (identifier)
+            type: (primitive_type))))
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters
+          (function_parameter
+            name: (identifier)
+            type: (primitive_type)))
+        return_type: (primitive_type)
+        (access_specifier
+          (access_specifier_arg
+            (identifier)))
+        body: (block
+          (num_literal)))
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters
+          (function_parameter
+            name: (identifier)
+            type: (primitive_type)))
+        (access_specifier
+          (access_specifier_arg
+            (identifier)))
+        body: (block))
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters
+          (function_parameter
+            name: (identifier)
+            type: (primitive_type)))
+        return_type: (primitive_type)
+        (access_specifier)
+        body: (block
+          (name_expression
+            (name_access_chain
+              (identifier))))))))
+
+================================================================================
+Positional struct unpack binding
+================================================================================
+
+module 0x1::test {
+    struct Pair(u64, u64) has copy, drop;
+    fun sum(p: Pair): u64 {
+        let Pair(x, y) = p;
+        x + y
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (struct_declaration
+        name: (identifier)
+        fields: (positional_fields
+          (primitive_type)
+          (primitive_type))
+        abilities: (ability_declarations
+          (ability)
+          (ability)))
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters
+          (function_parameter
+            name: (identifier)
+            type: (apply_type
+              (name_access_chain
+                (identifier)))))
+        return_type: (primitive_type)
+        body: (block
+          (let_expression
+            binds: (bind_positional_unpack
+              (name_access_chain
+                (identifier))
+              (bind_var
+                (identifier))
+              (bind_var
+                (identifier)))
+            value: (name_expression
+              (name_access_chain
+                (identifier))))
+          (binary_expression
+            lhs: (name_expression
+              (name_access_chain
+                (identifier)))
+            rhs: (name_expression
+              (name_access_chain
+                (identifier)))))))))
+
+================================================================================
+Struct and enum with post-body abilities
+================================================================================
+
+module 0x1::test {
+    struct Foo { x: u64 } has copy, drop;
+    enum Bar { V1, V2 } has copy, drop;
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (struct_declaration
+        name: (identifier)
+        fields: (struct_fields
+          (field_declaration
+            name: (identifier)
+            type: (primitive_type)))
+        post_abilities: (ability_declarations
+          (ability)
+          (ability)))
+      (enum_declaration
+        name: (identifier)
+        (enum_variant
+          name: (identifier))
+        (enum_variant
+          name: (identifier))
+        post_abilities: (ability_declarations
+          (ability)
+          (ability))))))
+
+================================================================================
+Spec emits clause
+================================================================================
+
+module 0x1::test {
+    struct Ev has drop, store { v: u64 }
+    fun emit_ev(handle: &0x1::event::EventHandle<Ev>, v: u64) {
+        0x1::event::emit_event(handle, Ev { v });
+    }
+    spec emit_ev {
+        emits Ev { v: v } to handle;
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (struct_declaration
+        name: (identifier)
+        abilities: (ability_declarations
+          (ability)
+          (ability))
+        fields: (struct_fields
+          (field_declaration
+            name: (identifier)
+            type: (primitive_type))))
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters
+          (function_parameter
+            name: (identifier)
+            type: (ref_type
+              (apply_type
+                (name_access_chain
+                  (numerical_address)
+                  (identifier)
+                  (identifier))
+                (type_arguments
+                  (apply_type
+                    (name_access_chain
+                      (identifier)))))))
+          (function_parameter
+            name: (identifier)
+            type: (primitive_type)))
+        body: (block
+          (call_expression
+            function: (name_access_chain
+              (numerical_address)
+              (identifier)
+              (identifier))
+            arguments: (arg_list
+              (name_expression
+                (name_access_chain
+                  (identifier)))
+              (pack_expression
+                type: (name_access_chain
+                  (identifier))
+                (field_initializer
+                  field: (identifier)))))))
+      (spec_block
+        target: (name_access_chain
+          (identifier))
+        body: (spec_body
+          (spec_emits
+            (pack_expression
+              type: (name_access_chain
+                (identifier))
+              (field_initializer
+                field: (identifier)
+                value: (name_expression
+                  (name_access_chain
+                    (identifier)))))
+            (name_expression
+              (name_access_chain
+                (identifier)))))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -514,3 +514,58 @@ module 0x1::test {
               (name_expression
                 (name_access_chain
                   (identifier))))))))))
+
+================================================================================
+Unit expression
+================================================================================
+
+module 0x1::test {
+    fun f(): () {
+        ()
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters)
+        return_type: (unit_type)
+        body: (block
+          (unit_expression))))))
+
+================================================================================
+Loop with inline spec block
+================================================================================
+
+module 0x1::test {
+    fun f() {
+        loop {} spec { invariant true; }
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters)
+        body: (block
+          (loop_expression
+            body: (block)
+            spec: (spec_block
+              body: (spec_body
+                (spec_invariant
+                  (bool_literal))))))))))
+

--- a/test/corpus/spec_language.txt
+++ b/test/corpus/spec_language.txt
@@ -865,3 +865,115 @@ module 0x1::test {
             (field_declaration
               name: (identifier)
               type: (primitive_type))))))))
+
+================================================================================
+While with inline spec block
+================================================================================
+
+module 0x1::test {
+    fun f(n: u64) {
+        let i = 0;
+        while (i < n) {
+            i = i + 1;
+        } spec {
+            invariant i <= n;
+        };
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters
+          (function_parameter
+            name: (identifier)
+            type: (primitive_type)))
+        body: (block
+          (let_expression
+            binds: (bind_var
+              (identifier))
+            value: (num_literal))
+          (while_expression
+            condition: (binary_expression
+              lhs: (name_expression
+                (name_access_chain
+                  (identifier)))
+              rhs: (name_expression
+                (name_access_chain
+                  (identifier))))
+            body: (block
+              (assign_expression
+                lhs: (name_expression
+                  (name_access_chain
+                    (identifier)))
+                rhs: (binary_expression
+                  lhs: (name_expression
+                    (name_access_chain
+                      (identifier)))
+                  rhs: (num_literal))))
+            spec: (spec_block
+              body: (spec_body
+                (spec_invariant
+                  (binary_expression
+                    lhs: (name_expression
+                      (name_access_chain
+                        (identifier)))
+                    rhs: (name_expression
+                      (name_access_chain
+                        (identifier)))))))))))))
+
+================================================================================
+Lambda with inline spec block
+================================================================================
+
+module 0x1::test {
+    fun f() {
+        let add = |x: u64| x + 1 spec { ensures result == x + 1; };
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (module_declaration
+    name: (module_identity
+      address: (numerical_address)
+      module: (identifier))
+    body: (module_body
+      (function_declaration
+        name: (identifier)
+        parameters: (function_parameters)
+        body: (block
+          (let_expression
+            binds: (bind_var
+              (identifier))
+            value: (lambda_expression
+              parameters: (lambda_parameters
+                (lambda_parameter
+                  bind: (bind_var
+                    (identifier))
+                  type: (primitive_type)))
+              body: (binary_expression
+                lhs: (name_expression
+                  (name_access_chain
+                    (identifier)))
+                rhs: (num_literal))
+              spec: (spec_block
+                body: (spec_body
+                  (spec_condition
+                    (binary_expression
+                      lhs: (name_expression
+                        (name_access_chain
+                          (identifier)))
+                      rhs: (binary_expression
+                        lhs: (name_expression
+                          (name_access_chain
+                            (identifier)))
+                        rhs: (num_literal)))))))))))))


### PR DESCRIPTION
## Summary

- Adds `coverage.py`: measures named node types and named fields from `src/node-types.json` against corpus tests; enforced at 100% in CI
- Adds `diff-test.py`: differential test that detects hidden `ERROR`/`MISSING` nodes in files tree-sitter "accepts" (exit 0), complementing `batch-test.py`
- Adds 11 new corpus tests to fill all coverage gaps, reaching 100% on both node-type and field coverage

## Coverage details

```
Node type coverage:  129/129 (100.0%)
Named field coverage: 124/124 (100.0%)
```

New corpus tests cover: `unit_expression`, `loop_expression.spec`, `inline_modifier`, `access_specifier`, `access_specifier_arg`, `bind_positional_unpack`, struct/enum `post_abilities`, `spec_emits`, `while_expression.spec`, `lambda_expression.spec`.

`coverage.py` correctly excludes anonymous-only fields (e.g. `assign_expression.op`) that cannot appear as named nodes in S-expression output.

## Test plan

- [ ] `python3 coverage.py --min-node-pct 100 --min-field-pct 100` exits 0
- [ ] `npx tree-sitter test` shows 116/116 passing
- [ ] CI `Check corpus coverage` step passes in the new workflow